### PR TITLE
Feat/49 label functions

### DIFF
--- a/internal/kubernetes/labeller.go
+++ b/internal/kubernetes/labeller.go
@@ -1,0 +1,26 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+func PatchPvcLabel(kube kubernetes.Interface, label string, value string, ns string, pvc string) {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, label, value))
+	_, err := kube.CoreV1().PersistentVolumeClaims(ns).Patch(
+		context.TODO(),
+		pvc,
+		types.MergePatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		log.Fatalf("Error patching PVC %s from namespace %s: %v", pvc, ns, err)
+	}
+
+}

--- a/internal/kubernetes/labeller.go
+++ b/internal/kubernetes/labeller.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func PatchPvcLabel(kube kubernetes.Interface, label string, value string, ns string, pvc string) {
-	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, label, value))
+func patchPvcLabel(kube kubernetes.Interface, label string, value string, ns string, pvc string) {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":%s}}}`, label, value))
 	_, err := kube.CoreV1().PersistentVolumeClaims(ns).Patch(
 		context.TODO(),
 		pvc,
@@ -23,4 +23,12 @@ func PatchPvcLabel(kube kubernetes.Interface, label string, value string, ns str
 		log.Fatalf("Error patching PVC %s from namespace %s: %v", pvc, ns, err)
 	}
 
+}
+
+func SetPvcLabel(kube kubernetes.Interface, label string, value string, ns string, pvc string) {
+	patchPvcLabel(kube, label, fmt.Sprintf(`"%s"`, value), ns, pvc)
+}
+
+func RemovePvcLabel(kube kubernetes.Interface, label string, ns string, pvc string) {
+	patchPvcLabel(kube, label, "null", ns, pvc)
 }

--- a/internal/kubernetes/labeller_test.go
+++ b/internal/kubernetes/labeller_test.go
@@ -23,12 +23,10 @@ func TestAddPvcLabel(t *testing.T) {
 			t.Fatalf("Error injecting namespace add: %v", err)
 		}
 
-		{
-			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "test"}}
-			_, err := client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), pvc, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatalf("Error injecting pvc add: %v", err)
-			}
+		pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "test"}}
+		_, err = client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), pvc, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Error injecting pvc add: %v", err)
 		}
 
 		// test adding new label

--- a/internal/kubernetes/labeller_test.go
+++ b/internal/kubernetes/labeller_test.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAddPvcLabel(t *testing.T) {
+
+	t.Run("add label to pvc", func(t *testing.T) {
+		// create fake client
+		client := fake.NewClientset()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test",
+			Labels: map[string]string{"app.kubernetes.io/part-of": "kubeflow-profile"}}}
+		_, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Error injecting namespace add: %v", err)
+		}
+
+		{
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "test"}}
+			_, err := client.CoreV1().PersistentVolumeClaims("test").Create(context.TODO(), pvc, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error injecting pvc add: %v", err)
+			}
+		}
+
+		PatchPvcLabel(client, "volume-cleaner/unattached-time", "foo", "test", "pvc1")
+
+		assert.Equal(t, PvcList(client, "test")[0].Labels["volume-cleaner/unattached-time"], "foo")
+	})
+}

--- a/internal/kubernetes/labeller_test.go
+++ b/internal/kubernetes/labeller_test.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestAddPvcLabel(t *testing.T) {
+func TestLabelFunctions(t *testing.T) {
 
-	t.Run("add label to pvc", func(t *testing.T) {
+	t.Run("test add, remove, edit labels", func(t *testing.T) {
 		// create fake client
 		client := fake.NewClientset()
 

--- a/internal/kubernetes/labeller_test.go
+++ b/internal/kubernetes/labeller_test.go
@@ -31,8 +31,21 @@ func TestAddPvcLabel(t *testing.T) {
 			}
 		}
 
-		PatchPvcLabel(client, "volume-cleaner/unattached-time", "foo", "test", "pvc1")
+		// test adding new label
+		SetPvcLabel(client, "volume-cleaner/unattached-time", "foo", "test", "pvc1")
 
 		assert.Equal(t, PvcList(client, "test")[0].Labels["volume-cleaner/unattached-time"], "foo")
+
+		// test changing existing label
+		SetPvcLabel(client, "volume-cleaner/unattached-time", "bar", "test", "pvc1")
+
+		assert.Equal(t, PvcList(client, "test")[0].Labels["volume-cleaner/unattached-time"], "bar")
+
+		// test removing label
+		RemovePvcLabel(client, "volume-cleaner/unattached-time", "test", "pvc1")
+
+		_, ok := PvcList(client, "test")[0].Labels["volume-cleaner/unattached-time"]
+
+		assert.Equal(t, ok, false)
 	})
 }

--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -27,7 +27,7 @@ func NsList(kube kubernetes.Interface) []corev1.Namespace {
 	return ns.Items
 }
 
-// returns a slice of corev1.PersistentVolumeClaim structs
+// returns a slice of corev1.PersistentVolumeClaim structs in a given namespace
 
 func PvcList(kube kubernetes.Interface, name string) []corev1.PersistentVolumeClaim {
 	pvcs, err := kube.CoreV1().PersistentVolumeClaims(name).List(context.TODO(), metav1.ListOptions{})
@@ -37,7 +37,7 @@ func PvcList(kube kubernetes.Interface, name string) []corev1.PersistentVolumeCl
 	return pvcs.Items
 }
 
-// returns a slice of appv1.StatefulSet structs
+// returns a slice of appv1.StatefulSet structs in a given namespace
 
 func StsList(kube kubernetes.Interface, name string) []appv1.StatefulSet {
 	sts, err := kube.AppsV1().StatefulSets(name).List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
### Proposed Changes/Description 

- Completes ticket #49
- `SetPvcLabel(kube kubernetes.Interface, label string, value string, ns string, pvc string)` is used to add or change a label on a PVC
- `RemovePvcLabel(kube kubernetes.Interface, label string, ns string, pvc string)` is used to delete a label on a PVC

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Related Issue/Ticket

closes: #49 

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
