### PR TITLE
feat: set up watcher to apply labels

### DIFF
--- a/cmd/volume_cleaner/main.go
+++ b/cmd/volume_cleaner/main.go
@@ -31,6 +31,8 @@ func main() {
 		log.Fatalf("Error creating kube client: %v", err)
 	}
 
+	kubeInternal.WatchSts(kubeClient)
+
 	cleanVolumes(kubeClient, cfg)
 }
 

--- a/internal/kubernetes/labeller.go
+++ b/internal/kubernetes/labeller.go
@@ -21,6 +21,8 @@ func patchPvcLabel(kube kubernetes.Interface, label string, value string, ns str
 	)
 	if err != nil {
 		log.Fatalf("Error patching PVC %s from namespace %s: %v", pvc, ns, err)
+	} else {
+		log.Printf("Patch successfully applied to %s", pvc)
 	}
 
 }

--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -47,20 +47,25 @@ func StsList(kube kubernetes.Interface, name string) []appv1.StatefulSet {
 	return sts.Items
 }
 
-// returns a slice of corev1.PersistentVolumeClaim structs
-// NOTE: each PVC has an OwnerReference pointing to its attached StatefulSet
-
 func PvcListBySts(kube kubernetes.Interface, sts *appv1.StatefulSet) []corev1.PersistentVolumeClaim {
 	pvcList := PvcList(kube, sts.Namespace)
 
 	var owned []corev1.PersistentVolumeClaim
 
-	for pvc := range pvcList {
-		for _, owner := range pvcList[pvc].OwnerReferences {
+	found := false
+
+	for _, pvc := range pvcList {
+		for _, owner := range pvc.OwnerReferences {
 			if owner.UID == sts.UID {
-				owned = append(owned, pvcList[pvc])
+				owned = append(owned, pvc)
+				found = true
+			}
+			if found {
 				break
 			}
+		}
+		if found {
+			break
 		}
 	}
 

--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -52,20 +52,12 @@ func PvcListBySts(kube kubernetes.Interface, sts *appv1.StatefulSet) []corev1.Pe
 
 	var owned []corev1.PersistentVolumeClaim
 
-	found := false
-
 	for _, pvc := range pvcList {
 		for _, owner := range pvc.OwnerReferences {
 			if owner.UID == sts.UID {
 				owned = append(owned, pvc)
-				found = true
-			}
-			if found {
 				break
 			}
-		}
-		if found {
-			break
 		}
 	}
 

--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -47,23 +47,6 @@ func StsList(kube kubernetes.Interface, name string) []appv1.StatefulSet {
 	return sts.Items
 }
 
-func PvcListBySts(kube kubernetes.Interface, sts *appv1.StatefulSet) []corev1.PersistentVolumeClaim {
-	pvcList := PvcList(kube, sts.Namespace)
-
-	var owned []corev1.PersistentVolumeClaim
-
-	for _, pvc := range pvcList {
-		for _, owner := range pvc.OwnerReferences {
-			if owner.UID == sts.UID {
-				owned = append(owned, pvc)
-				break
-			}
-		}
-	}
-
-	return owned
-}
-
 // returns a slice of corev1.PersistentVolumeClaims that are all unattached (not associated with any statefulset)
 
 func FindUnattachedPVCs(kube kubernetes.Interface) []corev1.PersistentVolumeClaim {

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -37,10 +37,14 @@ func WatchSts(kube *kubernetes.Clientset) {
 		switch event.Type {
 		case watch.Added:
 			log.Printf("sts added: %s\n", sts)
-			RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", sts.Name)
+			for _, pvc := range PvcListBySts(kube, sts) {
+				RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", pvc.Name)
+			}
 		case watch.Deleted:
 			log.Printf("sts deleted: %s\n", sts)
-			SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", sts.Name)
+			for _, pvc := range PvcListBySts(kube, sts) {
+				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", pvc.Name)
+			}
 		}
 
 	}

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -43,7 +43,8 @@ func WatchSts(kube *kubernetes.Clientset) {
 			}
 		case watch.Deleted:
 			log.Printf("sts deleted: %s\n", sts.Name)
-			for _, pvc := range PvcListBySts(kube, sts) {
+			log.Print(sts.Spec.Template.Spec.Volumes)
+			for _, pvc := range sts.Spec.VolumeClaimTemplates {
 				log.Printf("adding label to sts")
 				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", pvc.Name)
 			}

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -13,7 +13,7 @@ import (
 
 // Watches for when statefulsets are created or deleted across all namespaces
 func watchSts(kube *kubernetes.Clientset) {
-	watcher, err := kube.AppsV1().StatefulSets(metav1.NamespaceAll).Watch(context.TODO(), metav1.ListOptions{})
+	watcher, err := kube.AppsV1().StatefulSets("anray-liu").Watch(context.TODO(), metav1.ListOptions{})
 
 	if err != nil {
 		log.Fatalf("Error creating a watcher for statefulsets: %v", err)

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -43,10 +43,9 @@ func WatchSts(kube *kubernetes.Clientset) {
 			}
 		case watch.Deleted:
 			log.Printf("sts deleted: %s\n", sts.Name)
-			log.Print(sts.Spec.Template.Spec.Volumes)
-			for _, pvc := range sts.Spec.VolumeClaimTemplates {
+			for _, vol := range sts.Spec.Template.Spec.Volumes {
 				log.Printf("adding label to sts")
-				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", pvc.Name)
+				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", vol.Name)
 			}
 		}
 

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Watches for when statefulsets are created or deleted across all namespaces
-func watchSts(kube *kubernetes.Clientset) {
+func WatchSts(kube *kubernetes.Clientset) {
 	watcher, err := kube.AppsV1().StatefulSets("anray-liu").Watch(context.TODO(), metav1.ListOptions{})
 
 	if err != nil {

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -37,15 +37,15 @@ func WatchSts(kube *kubernetes.Clientset) {
 		switch event.Type {
 		case watch.Added:
 			log.Printf("sts added: %s\n", sts.Name)
-			for _, pvc := range PvcListBySts(kube, sts) {
-				log.Printf("removing label from sts")
-				RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", pvc.Name)
+			for _, vol := range sts.Spec.Template.Spec.Volumes {
+				log.Printf("removing label")
+				RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", vol.PersistentVolumeClaim.ClaimName)
 			}
 		case watch.Deleted:
 			log.Printf("sts deleted: %s\n", sts.Name)
 			for _, vol := range sts.Spec.Template.Spec.Volumes {
-				log.Printf("adding label to sts")
-				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().Format("2006-01-02_15-04-05Z"), "anray-liu", vol.Name)
+				log.Printf("adding label")
+				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().Format("2006-01-02_15-04-05Z"), "anray-liu", vol.PersistentVolumeClaim.ClaimName)
 			}
 		}
 

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -36,13 +36,15 @@ func WatchSts(kube *kubernetes.Clientset) {
 
 		switch event.Type {
 		case watch.Added:
-			log.Printf("sts added: %s\n", sts)
+			log.Printf("sts added: %s\n", sts.Name)
 			for _, pvc := range PvcListBySts(kube, sts) {
+				log.Printf("removing label from sts")
 				RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", pvc.Name)
 			}
 		case watch.Deleted:
-			log.Printf("sts deleted: %s\n", sts)
+			log.Printf("sts deleted: %s\n", sts.Name)
 			for _, pvc := range PvcListBySts(kube, sts) {
+				log.Printf("adding label to sts")
 				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", pvc.Name)
 			}
 		}

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -45,7 +45,7 @@ func WatchSts(kube *kubernetes.Clientset) {
 			log.Printf("sts deleted: %s\n", sts.Name)
 			for _, vol := range sts.Spec.Template.Spec.Volumes {
 				log.Printf("adding label to sts")
-				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", vol.Name)
+				SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().Format("2006-01-02_15-04-05Z"), "anray-liu", vol.Name)
 			}
 		}
 

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -4,6 +4,7 @@ import (
 	// External Imports
 	"context"
 	"log"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,10 +37,10 @@ func WatchSts(kube *kubernetes.Clientset) {
 		switch event.Type {
 		case watch.Added:
 			log.Printf("sts added: %s\n", sts)
-			// Call Labeler
+			RemovePvcLabel(kube, "volume-cleaner/unattached-time", "anray-liu", sts.Name)
 		case watch.Deleted:
 			log.Printf("sts deleted: %s\n", sts)
-			// Call Labeler
+			SetPvcLabel(kube, "volume-cleaner/unattached-time", time.Now().String(), "anray-liu", sts.Name)
 		}
 
 	}

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -18,7 +18,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "patch"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "watch"]

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Proposed Changes/Description 

The controller can now watch stateful sets and apply labels to persistent volume claims. When a pvc is detached , it is assigned the current timestamp. When it is reattached, the label is removed.

The next step would be to make the controller find unaccounted for pvcs on start up. 

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Related Issue/Ticket

#45

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [ ] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
