### PR TITLE
ci(unit test): add golang unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: super-linter/super-linter@v7
         env:
           DEFAULT_BRANCH: main
+          MULTI_STATUS: ${{ env.ACT && 'false' || 'true' }}
           VALIDATE_ALL_CODEBASE: false 
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_GITHUB_ACTIONS: true
@@ -30,6 +31,29 @@ jobs:
           VALIDATE_GITLEAKS: true
           VALIDATE_YAML: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    name: Golang Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      # allows workflow to access the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Go mod tidy (ensure dependencies are clean)
+        run: go mod tidy -v
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Run Go tests
+        run: go test -v -race ./...
 
   build-push:
     runs-on: ubuntu-latest
@@ -40,6 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to ACR
+        if: ${{ !env.ACT }}
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.REGISTRY }}
@@ -52,9 +77,10 @@ jobs:
           context: .
           file: ./docker/controller/Dockerfile
           tags: ${{ env.REGISTRY }}/volume-cleaner-controller:latest
-          push: true 
+          push: ${{ env.ACT && 'false' || 'true' }} 
 
       - name: Security Scan
+        if: ${{ !env.ACT }}
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/volume-cleaner-controller:latest


### PR DESCRIPTION

### Proposed Changes/Description 

- Two primary changes have been made, firstly, the workflow will now run the golang unit tests and integration tests via go test. Secondly, flags have been added to allow for local testing of github actions via act. Running act locally will now no longer try to sign into azure to push to ACR or do remote trivy scans of the ACR image

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [x] Other (if none of the other choices apply)

### Testing

Run `act --rm` locally at the root directory of the project

### Screenshots (if applicable) 

This screenshot is not exactly the most informative, its just additional proof that the ci pipeline passes locally via act

<img width="701" alt="image" src="https://github.com/user-attachments/assets/01a35948-1c19-4de4-90f0-2605949eac7d" />

### Related Issue/Ticket

Closes #53 

### Checklist

- [ ] ~~README.md or the Github Wiki documentation updated - if appropriate~~
- [ ] ~~Unit and/or integration tests added/modified~~
- [x] Lint and Unit tests pass locally with my changes
