### PR TITLE
refactor: split makefile into smaller files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,11 @@
 first: # prevents accidental running of make rules
 	@echo "Please use explicit make commands with volume cleaner."
 
-run-controller:
-	@echo "🚧 Starting run..."
-	@echo "🧰 Setting up run dependencies..."
-	@kubectl apply -f manifests/rbac.yaml \
-		-f manifests/serviceaccount.yaml \
-		-f manifests/netpol.yaml \
-		-f manifests/controller/controller_config.yaml
-	@kubectl -n das apply -f manifests/controller/controller_deployment.yaml
-	@echo "Ready to go!"
+run_controller:
+	@make -C scripts/controller run_controller
 
-run-scheduler:
-	@echo "🚧 Starting run..."
-	@echo "🧰 Setting up run dependencies..."
-	@kubectl apply -f manifests/rbac.yaml \
-		-f manifests/serviceaccount.yaml \
-		-f manifests/netpol.yaml \
-		-f manifests/scheduler/scheduler_config.yaml
-	@kubectl -n das apply -f manifests/scheduler/scheduler_job.yaml
-	@kubectl -n das wait --for=condition=complete job volume-cleaner-scheduler --timeout=300s || \
-		(echo "Pod did not become ready"; exit 1)
-	@echo "Pod logs:"
-	@kubectl -n das logs -l job-name=volume-cleaner-scheduler --tail 500
+run_scheduler:
+	@make -C scripts/scheduler run_scheduler
 
 clean:
 	@echo "🧼 Cleaning up leftover resources..."

--- a/scripts/.keep
+++ b/scripts/.keep
@@ -1,1 +1,0 @@
-Remove this file when you start adding files into it

--- a/scripts/controller/Makefile
+++ b/scripts/controller/Makefile
@@ -1,0 +1,9 @@
+run_controller:
+	@echo "🚧 Starting run..."
+	@echo "🧰 Setting up run dependencies..."
+	@kubectl apply -f ../../manifests/rbac.yaml \
+		-f ../../manifests/serviceaccount.yaml \
+		-f ../../manifests/netpol.yaml \
+		-f ../../manifests/controller/controller_config.yaml
+	@kubectl -n das apply -f ../../manifests/controller/controller_deployment.yaml
+	@echo "Ready to go!"

--- a/scripts/scheduler/Makefile
+++ b/scripts/scheduler/Makefile
@@ -1,0 +1,13 @@
+run_scheduler:
+	@echo "🚧 Starting run..."
+	@echo "🧰 Setting up run dependencies..."
+	@kubectl apply -f ../../manifests/rbac.yaml \
+		-f ../../manifests/serviceaccount.yaml \
+		-f ../../manifests/netpol.yaml \
+		-f ../../manifests/scheduler/scheduler_config.yaml
+	@kubectl -n das apply -f ../../manifests/scheduler/scheduler_job.yaml
+	@kubectl -n das wait --for=condition=complete job volume-cleaner-scheduler --timeout=300s || \
+		(echo "Pod did not become ready"; exit 1)
+	@echo "Pod logs:"
+	@kubectl -n das logs -l job-name=volume-cleaner-scheduler --tail 500
+


### PR DESCRIPTION
### Proposed Changes/Description 

Split makefile into a separate one for controller and scheduler. This isn't really needed for now, but we thought it was best to do it now so it's easier in the future.

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [x] Other (if none of the other choices apply)

### Related Issue/Ticket
#59 

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
