### PR TITLE
feat: add integration with secret manifest

### DIFF
--- a/manifests/scheduler/scheduler_config.yaml
+++ b/manifests/scheduler/scheduler_config.yaml
@@ -11,3 +11,5 @@ data:
   TIME_FORMAT: "2006-01-02_15-04-05Z"
   DRY_RUN: "true"
   NOTIF_TIMES: "1, 2, 3, 4"
+  BASE_URL: "https://api.notification.canada.ca"
+  ENDPOINT: "/v2/notifications/email"

--- a/manifests/scheduler/scheduler_secret.yaml
+++ b/manifests/scheduler/scheduler_secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: volume-cleaner-scheduler-secret
+  namespace: das
+type: Opaque
+data:
+  API_KEY: "dGVzdA=="             # test
+  EMAIL_TEMPLATE_ID: "dGVzdA=="   # test

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,6 +1,7 @@
 apply:
 	@minikube kubectl -- apply -f manifests.yaml
 	@minikube kubectl -- apply -f ../manifests/scheduler/scheduler_config.yaml \
+							-f  ../manifests/scheduler/scheduler_secret.yaml \
 							-f  ../manifests/controller/controller_config.yaml \
 							-f	  ../manifests/netpol.yaml \
 							-f	  ../manifests/rbac.yaml \

--- a/testing/scheduler_job.yaml
+++ b/testing/scheduler_job.yaml
@@ -20,4 +20,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: volume-cleaner-scheduler-config
+            - secretRef:
+                name: volume-cleaner-scheduler-secret
       restartPolicy: Never


### PR DESCRIPTION
### Proposed Changes/Description 

This PR allows the email service to integrate with Kubernetes secrets, protecting important information while keeping values configurable. Tested on a local cluster. Also pushed a skeleton of the secrets manifest, but it is still in the gitignore to prevent accidental leaking of important data.

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Related Issue/Ticket

Closes #105 

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
