### PR TITLE
feat(notif): Implement backfilling notification logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,11 +251,11 @@ jobs:
 
       - name: Test scheduler for pvc1
         run: |
-          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc1 from namespace anray-liu"; then
+          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500 | grep "Found pvc pvc1 from namespace anray-liu"; then
               echo "Scheduler didn't find pvc1. Test failed."
               exit 2
           else
-              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc1 from namespace anray-liu" -A 3 | grep "Grace period not passed."; then
+              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500 | grep "Found pvc pvc1 from namespace anray-liu" -A 3 | grep "Grace period not passed."; then
                   echo "Scheduler didn't skip pvc1. Test failed."
                   exit 2
               else
@@ -265,11 +265,11 @@ jobs:
 
       - name: Test scheduler for pvc2
         run: |
-          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc2 from namespace anray-liu"; then
+          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500 | grep "Found pvc pvc2 from namespace anray-liu"; then
               echo "Scheduler didn't find pvc2. Test failed."
               exit 2
           else
-              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc2 from namespace anray-liu" -A 1 | grep "Not labelled. Skipping."; then
+              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500 | grep "Found pvc pvc2 from namespace anray-liu" -A 1 | grep "Not labelled. Skipping."; then
                   echo "Scheduler didn't skip pvc2. Test failed."
                   exit 2
               else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,7 +239,7 @@ jobs:
       - name: Apply scheduler
         run: |
           kubectl apply -f testing/scheduler/scheduler_job.yaml
-          sleep 5
+          sleep 10
 
       - name: Test scheduler for pvc1
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,11 +182,11 @@ jobs:
           fi
           OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep -A 2 "labels:")"
           if [[ "${OUTPUT}" == *"volume-cleaner/unattached-time:"* ]] && [[ "${OUTPUT}" == *"volume-cleaner/notification-count:"* ]]; then
-            echo "Both labels found. Test passed."
+              echo "Both labels found. Test passed."
           else
-            echo "Output: ${OUTPUT}"
-            echo "Expected both labels, but one or both are missing. Test failed."
-            exit 2
+              echo "Output: ${OUTPUT}"
+              echo "Expected both labels, but one or both are missing. Test failed."
+              exit 2
           fi
 
       - name: Test label not applied
@@ -229,11 +229,11 @@ jobs:
           fi
           OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep -A 2 "labels:")"
           if [[ "${OUTPUT}" == *"volume-cleaner/unattached-time:"* ]] && [[ "${OUTPUT}" == *"volume-cleaner/notification-count:"* ]]; then
-            echo "Both labels found again. Test passed."
+              echo "Both labels found again. Test passed."
           else
-            echo "Output: ${OUTPUT}"
-            echo "Expected both labels, but one or both are missing. Test failed."
-            exit 2
+              echo "Output: ${OUTPUT}"
+              echo "Expected both labels, but one or both are missing. Test failed."
+              exit 2
           fi
 
       - name: Apply scheduler

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,15 +179,14 @@ jobs:
           if ! kubectl get pvc pvc1 -n anray-liu -o yaml | grep -q labels; then
               echo "No labels found. Test failed."
               exit 2
+          fi
+          OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep -A 2 "labels:")"
+          if [[ "${OUTPUT}" == *"volume-cleaner/unattached-time:"* ]] && [[ "${OUTPUT}" == *"volume-cleaner/notification-count:"* ]]; then
+            echo "Both labels found. Test passed."
           else
-              OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep labels -A 1)"
-              if [[ "${OUTPUT}" = *"volume-cleaner/unattached-time:"* ]]; then
-                  echo "Test passed."
-              else
-                  echo "Output: ${OUTPUT}"
-                  echo "Wrong label found. Test failed."
-                  exit 2
-              fi
+            echo "Output: ${OUTPUT}"
+            echo "Expected both labels, but one or both are missing. Test failed."
+            exit 2
           fi
 
       - name: Test label not applied
@@ -227,15 +226,14 @@ jobs:
           if ! kubectl get pvc pvc1 -n anray-liu -o yaml | grep -q labels; then
               echo "No labels found. Test failed."
               exit 2
+          fi
+          OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep -A 2 "labels:")"
+          if [[ "${OUTPUT}" == *"volume-cleaner/unattached-time:"* ]] && [[ "${OUTPUT}" == *"volume-cleaner/notification-count:"* ]]; then
+            echo "Both labels found again. Test passed."
           else
-              OUTPUT="$(kubectl get pvc pvc1 -n anray-liu -o yaml | grep labels -A 1)"
-              if [[ "${OUTPUT}" = *"volume-cleaner/unattached-time:"* ]]; then
-                  echo "Test passed."
-              else
-                  echo "Output: ${OUTPUT}"
-                  echo "Wrong label found. Test failed."
-                  exit 2
-              fi
+            echo "Output: ${OUTPUT}"
+            echo "Expected both labels, but one or both are missing. Test failed."
+            exit 2
           fi
 
       - name: Apply scheduler

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,6 +241,12 @@ jobs:
           kubectl apply -f testing/scheduler/scheduler_job.yaml
           sleep 10
 
+      # extra information
+      - name: Print logs
+        run: |
+          kubectl logs -l app=volume-cleaner-controller -n das
+          kubectl logs -l app=volume-cleaner-scheduler -n das
+
       - name: Test scheduler for pvc1
         run: |
           if ! kubectl logs -l app=volume-cleaner-scheduler -n das | grep "Found pvc pvc1 from namespace anray-liu"; then
@@ -268,9 +274,3 @@ jobs:
                   echo "Test passed."
               fi
           fi
-
-      # extra information
-      - name: Print logs
-        run: |
-          kubectl logs -l app=volume-cleaner-controller -n das
-          kubectl logs -l app=volume-cleaner-scheduler -n das

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,16 +244,18 @@ jobs:
       # extra information
       - name: Print logs
         run: |
+          echo "----------controller----------"
           kubectl logs -l app=volume-cleaner-controller -n das --tail 500
           kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500
+          echo "----------scheduler----------"
 
       - name: Test scheduler for pvc1
         run: |
-          if ! kubectl logs -l app=volume-cleaner-scheduler -n das | grep "Found pvc pvc1 from namespace anray-liu"; then
+          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc1 from namespace anray-liu"; then
               echo "Scheduler didn't find pvc1. Test failed."
               exit 2
           else
-              if ! kubectl logs -l app=volume-cleaner-scheduler -n das | grep "Found pvc pvc1 from namespace anray-liu" -A 3 | grep "Grace period not passed."; then
+              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc1 from namespace anray-liu" -A 3 | grep "Grace period not passed."; then
                   echo "Scheduler didn't skip pvc1. Test failed."
                   exit 2
               else
@@ -263,11 +265,11 @@ jobs:
 
       - name: Test scheduler for pvc2
         run: |
-          if ! kubectl logs -l app=volume-cleaner-scheduler -n das | grep "Found pvc pvc2 from namespace anray-liu"; then
+          if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc2 from namespace anray-liu"; then
               echo "Scheduler didn't find pvc2. Test failed."
               exit 2
           else
-              if ! kubectl logs -l app=volume-cleaner-scheduler -n das | grep "Found pvc pvc2 from namespace anray-liu" -A 1 | grep "Not labelled. Skipping."; then
+              if ! kubectl logs -l app=volume-cleaner-scheduler -n das --tail | grep "Found pvc pvc2 from namespace anray-liu" -A 1 | grep "Not labelled. Skipping."; then
                   echo "Scheduler didn't skip pvc2. Test failed."
                   exit 2
               else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,8 +244,8 @@ jobs:
       # extra information
       - name: Print logs
         run: |
-          kubectl logs -l app=volume-cleaner-controller -n das
-          kubectl logs -l app=volume-cleaner-scheduler -n das
+          kubectl logs -l app=volume-cleaner-controller -n das --tail 500
+          kubectl logs -l app=volume-cleaner-scheduler -n das --tail 500
 
       - name: Test scheduler for pvc1
         run: |

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -32,7 +32,8 @@ func main() {
 
 	cfg := structInternal.ControllerConfig{
 		Namespace:  os.Getenv("NAMESPACE"),
-		Label:      os.Getenv("LABEL"),
+		TimeLabel:  os.Getenv("TIME_LABEL"),
+		NotifLabel: os.Getenv("NOTIF_LABEL"),
 		TimeFormat: os.Getenv("TIME_FORMAT"),
 	}
 

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -31,7 +31,8 @@ func main() {
 
 	cfg := structInternal.SchedulerConfig{
 		Namespace:   os.Getenv("NAMESPACE"),
-		Label:       os.Getenv("LABEL"),
+		TimeLabel:   os.Getenv("TIME_LABEL"),
+		NotifLabel:  os.Getenv("NOTIF_LABEL"),
 		TimeFormat:  os.Getenv("TIME_FORMAT"),
 		GracePeriod: gracePeriod,
 		DryRun:      os.Getenv("DRY_RUN") == "true" || os.Getenv("DRY_RUN") == "1",

--- a/internal/kubernetes/finder.go
+++ b/internal/kubernetes/finder.go
@@ -83,10 +83,10 @@ func FindStale(kube kubernetes.Interface, cfg structInternal.SchedulerConfig) {
 					log.Printf("Error reading label: %s", cfg.NotifLabel)
 					continue
 				}
-				currNotif, err := strconv.Atoi(notifCount)
+				currNotif, errCount := strconv.Atoi(notifCount)
 
-				if err != nil {
-					log.Printf("Error converting notification-count '%s': %v", notifCount, err)
+				if errCount != nil {
+					log.Printf("Error converting notification-count '%s': %v", notifCount, errCount)
 					continue
 				}
 

--- a/internal/kubernetes/finder.go
+++ b/internal/kubernetes/finder.go
@@ -83,10 +83,10 @@ func FindStale(kube kubernetes.Interface, cfg structInternal.SchedulerConfig) {
 					log.Printf("Error reading label: %s", cfg.NotifLabel)
 					continue
 				}
-				currNotif, errCount := strconv.Atoi(notifCount)
+				currNotif, countErr := strconv.Atoi(notifCount)
 
-				if errCount != nil {
-					log.Printf("Error converting notification-count '%s': %v", notifCount, errCount)
+				if countErr != nil {
+					log.Printf("Error converting notification-count '%s': %v", notifCount, countErr)
 					continue
 				}
 

--- a/internal/kubernetes/finder.go
+++ b/internal/kubernetes/finder.go
@@ -86,7 +86,8 @@ func FindStale(kube kubernetes.Interface, cfg structInternal.SchedulerConfig) {
 				currNotif, err := strconv.Atoi(notifCount)
 
 				if err != nil {
-					log.Printf("Error converting string label to int: %s", notifCount)
+					log.Printf("Error converting notification-count '%s': %v", notifCount, err)
+					continue
 				}
 
 				shouldSend, mailError := ShouldSendMail(timestamp, currNotif, cfg)

--- a/internal/kubernetes/finder_test.go
+++ b/internal/kubernetes/finder_test.go
@@ -102,7 +102,8 @@ func TestShouldSendMail(t *testing.T) {
 
 		cfg := structInternal.SchedulerConfig{
 			Namespace:   "test",
-			Label:       "volume-cleaner/unattached-time",
+			TimeLabel:   "volume-cleaner/unattached-time",
+			NotifLabel:  "volume-cleaner/notification-count",
 			GracePeriod: 180,
 			TimeFormat:  "2006-01-02_15-04-05Z",
 			DryRun:      true,

--- a/internal/kubernetes/finder_test.go
+++ b/internal/kubernetes/finder_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	// standard packages
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -99,11 +100,6 @@ func TestShouldSendMail(t *testing.T) {
 			t.Fatalf("Error injecting namespace add: %v", namespaceErr)
 		}
 
-		pvc, pvcErr := kube.CreatePersistentVolumeClaim(context.TODO(), "pvc", "test")
-		if pvcErr != nil {
-			t.Fatalf("Error injecting pvc add: %v", pvcErr)
-		}
-
 		cfg := structInternal.SchedulerConfig{
 			Namespace:   "test",
 			Label:       "volume-cleaner/unattached-time",
@@ -119,9 +115,14 @@ func TestShouldSendMail(t *testing.T) {
 			},
 		}
 
+		sort.Slice(cfg.NotifTimes, func(i, j int) bool {
+			return cfg.NotifTimes[i] > cfg.NotifTimes[j] // Descending
+		})
+
 		type testCase struct {
 			timestamp     string
 			expectedValue bool
+			currNotif     int
 		}
 
 		now := time.Now()
@@ -130,39 +131,207 @@ func TestShouldSendMail(t *testing.T) {
 			{
 				timestamp:     now.Format(cfg.TimeFormat),
 				expectedValue: false,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour * 24 * 150).Format(cfg.TimeFormat),
 				expectedValue: true,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 150).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 150).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 150).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 150).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour*24*150 - time.Hour).Format(cfg.TimeFormat),
 				expectedValue: true,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23).Format(cfg.TimeFormat),
 				expectedValue: true,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23 - time.Minute*59 - time.Second*59).Format(cfg.TimeFormat),
 				expectedValue: true,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23 - time.Minute*59 - time.Second*59).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23 - time.Minute*59 - time.Second*59).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23 - time.Minute*59 - time.Second*59).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour*24*150 - time.Hour*23 - time.Minute*59 - time.Second*59).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 151).Format(cfg.TimeFormat),
+				expectedValue: true,
+				currNotif:     0,
 			},
 			{
 				timestamp:     now.Add(-time.Hour * 24 * 151).Format(cfg.TimeFormat),
 				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 151).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 151).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 151).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour * 24 * 149).Format(cfg.TimeFormat),
 				expectedValue: false,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 149).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 149).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 149).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 149).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 			{
 				timestamp:     now.Add(-time.Hour * 24 * 177).Format(cfg.TimeFormat),
 				expectedValue: true,
+				currNotif:     0,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 177).Format(cfg.TimeFormat),
+				expectedValue: true,
+				currNotif:     1,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 177).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     2,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 177).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     3,
+			},
+			{
+				timestamp:     now.Add(-time.Hour * 24 * 177).Format(cfg.TimeFormat),
+				expectedValue: false,
+				currNotif:     4,
 			},
 		}
 
 		for _, test := range testCases {
-			v, err := ShouldSendMail(test.timestamp, *pvc, cfg)
+			v, err := ShouldSendMail(test.timestamp, test.currNotif, cfg)
 			if err != nil {
 				t.Fatal("ShouldSendMail failed.")
 			}

--- a/internal/kubernetes/labeller_test.go
+++ b/internal/kubernetes/labeller_test.go
@@ -43,5 +43,12 @@ func TestLabelFunctions(t *testing.T) {
 		_, ok := PvcList(kube, "test")[0].Labels["volume-cleaner/unattached-time"]
 
 		assert.Equal(t, ok, false)
+
+		// test 2 new label
+		SetPvcLabel(kube, "volume-cleaner/unattached-time", "foo", "test", "pvc1")
+		SetPvcLabel(kube, "volume-cleaner/notification-count", "0", "test", "pvc1")
+
+		assert.Equal(t, PvcList(kube, "test")[0].Labels["volume-cleaner/unattached-time"], "foo")
+		assert.Equal(t, PvcList(kube, "test")[0].Labels["volume-cleaner/notification-count"], "0")
 	})
 }

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -52,6 +52,8 @@ func WatchSts(ctx context.Context, kube kubernetes.Interface, cfg structInternal
 					log.Printf("removing label")
 
 					RemovePvcLabel(kube, cfg.Label, sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
+					// TODO: abstract label name out into config
+					RemovePvcLabel(kube, "volume-cleaner/notification-count", sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
 				}
 			case watch.Deleted:
 				log.Printf("sts deleted: %s", sts.Name)
@@ -60,6 +62,8 @@ func WatchSts(ctx context.Context, kube kubernetes.Interface, cfg structInternal
 					log.Printf("adding label")
 
 					SetPvcLabel(kube, cfg.Label, time.Now().Format(cfg.TimeFormat), sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
+					// TODO: abstract label name out into config
+					SetPvcLabel(kube, "volume-cleaner/notification-count", "0", sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
 				}
 			}
 		}
@@ -73,6 +77,9 @@ func InitialScan(kube kubernetes.Interface, cfg structInternal.ControllerConfig)
 		_, ok := pvc.Labels[cfg.Label]
 		if !ok {
 			SetPvcLabel(kube, cfg.Label, time.Now().Format(cfg.TimeFormat), pvc.Namespace, pvc.Name)
+
+			// TODO: abstract label name out into config
+			SetPvcLabel(kube, "volume-cleaner/notification-count", "0", pvc.Namespace, pvc.Name)
 		} else {
 			log.Print("PVC already has label. Skipping.")
 		}

--- a/internal/kubernetes/watcher_test.go
+++ b/internal/kubernetes/watcher_test.go
@@ -38,7 +38,8 @@ func TestWatcherLabelling(t *testing.T) {
 
 		cfg := structInternal.ControllerConfig{
 			Namespace:  "test",
-			Label:      "volume-cleaner/unattached-time",
+			TimeLabel:  "volume-cleaner/unattached-time",
+			NotifLabel: "volume-cleaner/notification-count",
 			TimeFormat: "2006-01-02_15-04-05Z",
 		}
 
@@ -151,7 +152,8 @@ func TestInitialScan(t *testing.T) {
 
 		cfg := structInternal.ControllerConfig{
 			Namespace:  "test",
-			Label:      "volume-cleaner/unattached-time",
+			TimeLabel:  "volume-cleaner/unattached-time",
+			NotifLabel: "volume-cleaner/notification-count",
 			TimeFormat: "2006-01-02_15-04-05Z",
 		}
 

--- a/internal/kubernetes/watcher_test.go
+++ b/internal/kubernetes/watcher_test.go
@@ -52,7 +52,13 @@ func TestWatcherLabelling(t *testing.T) {
 		_, ok := pvcs[0].Labels["volume-cleaner/unattached-time"]
 		assert.Equal(t, ok, false)
 
+		_, ok = pvcs[0].Labels["volume-cleaner/notification-count"]
+		assert.Equal(t, ok, false)
+
 		_, ok = pvcs[1].Labels["volume-cleaner/unattached-time"]
+		assert.Equal(t, ok, false)
+
+		_, ok = pvcs[1].Labels["volume-cleaner/notification-count"]
 		assert.Equal(t, ok, false)
 
 		// mock a stateful set attached to a pvc1
@@ -69,7 +75,13 @@ func TestWatcherLabelling(t *testing.T) {
 		_, ok = pvcs[0].Labels["volume-cleaner/unattached-time"]
 		assert.Equal(t, ok, false)
 
+		_, ok = pvcs[0].Labels["volume-cleaner/notification-count"]
+		assert.Equal(t, ok, false)
+
 		_, ok = pvcs[1].Labels["volume-cleaner/unattached-time"]
+		assert.Equal(t, ok, false)
+
+		_, ok = pvcs[1].Labels["volume-cleaner/notification-count"]
 		assert.Equal(t, ok, false)
 
 		// delete sts
@@ -86,7 +98,13 @@ func TestWatcherLabelling(t *testing.T) {
 		_, ok = pvcs[0].Labels["volume-cleaner/unattached-time"]
 		assert.Equal(t, ok, true)
 
+		_, ok = pvcs[0].Labels["volume-cleaner/notification-count"]
+		assert.Equal(t, ok, true)
+
 		_, ok = pvcs[1].Labels["volume-cleaner/unattached-time"]
+		assert.Equal(t, ok, false)
+
+		_, ok = pvcs[1].Labels["volume-cleaner/notification-count"]
 		assert.Equal(t, ok, false)
 
 		ctx.Done()
@@ -120,7 +138,13 @@ func TestInitialScan(t *testing.T) {
 		_, ok := pvcs[0].Labels["volume-cleaner/unattached-time"]
 		assert.Equal(t, ok, false)
 
+		_, ok = pvcs[0].Labels["volume-cleaner/notification-count"]
+		assert.Equal(t, ok, false)
+
 		_, ok = pvcs[1].Labels["volume-cleaner/unattached-time"]
+		assert.Equal(t, ok, false)
+
+		_, ok = pvcs[1].Labels["volume-cleaner/notification-count"]
 		assert.Equal(t, ok, false)
 
 		ctx := context.Background()
@@ -142,7 +166,13 @@ func TestInitialScan(t *testing.T) {
 		_, ok = pvcs[0].Labels["volume-cleaner/unattached-time"]
 		assert.Equal(t, ok, true)
 
+		_, ok = pvcs[0].Labels["volume-cleaner/notification-count"]
+		assert.Equal(t, ok, true)
+
 		_, ok = pvcs[1].Labels["volume-cleaner/unattached-time"]
+		assert.Equal(t, ok, true)
+
+		_, ok = pvcs[1].Labels["volume-cleaner/notification-count"]
 		assert.Equal(t, ok, true)
 
 		ctx.Done()

--- a/internal/structure/configs.go
+++ b/internal/structure/configs.go
@@ -26,13 +26,15 @@ API_KEY: "Random APIKEY",
 
 type ControllerConfig struct {
 	Namespace  string
-	Label      string
+	TimeLabel  string
+	NotifLabel string
 	TimeFormat string
 }
 
 type SchedulerConfig struct {
 	Namespace   string
-	Label       string
+	TimeLabel   string
+	NotifLabel  string
 	TimeFormat  string
 	GracePeriod int
 	DryRun      bool

--- a/internal/structure/configs.go
+++ b/internal/structure/configs.go
@@ -6,13 +6,15 @@ Example configs
 controller:
 
 NAMESPACE: "anray-liu"
-LABEL: "volume-cleaner/unattached-time"
+TIME_LABEL: "volume-cleaner/unattached-time"
+NOTIF_LABEL: "volume-cleaner/notification-count"
 TIME_FORMAT: "2006-01-02_15-04-05Z"
 
 scheduler:
 
 NAMESPACE: "anray-liu"
-LABEL: "volume-cleaner/unattached-time"
+TIME_LABEL: "volume-cleaner/unattached-time"
+NOTIF_LABEL: "volume-cleaner/notification-count"
 GRACE_PERIOD: "180"
 TIME_FORMAT: "2006-01-02_15-04-05Z"
 DRY_RUN: "true"

--- a/manifests/controller/controller_config.yaml
+++ b/manifests/controller/controller_config.yaml
@@ -6,5 +6,6 @@ metadata:
   namespace: das
 data:
   NAMESPACE: "anray-liu"
-  LABEL: "volume-cleaner/unattached-time"
+  TIME_LABEL: "volume-cleaner/unattached-time"
+  NOTIF_LABEL: "volume-cleaner/notification-count"
   TIME_FORMAT: "2006-01-02_15-04-05Z"

--- a/manifests/scheduler/scheduler_config.yaml
+++ b/manifests/scheduler/scheduler_config.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: das
 data:
   NAMESPACE: "anray-liu"
-  LABEL: "volume-cleaner/unattached-time"
+  TIME_LABEL: "volume-cleaner/unattached-time"
+  NOTIF_LABEL: "volume-cleaner/notification-count"
   GRACE_PERIOD: "7"
   TIME_FORMAT: "2006-01-02_15-04-05Z"
   DRY_RUN: "true"


### PR DESCRIPTION
### Proposed Changes/Description 

- This PR introduces a new label, a notification count label to ensure the number of notification emails specified is the number of emails sent. The new logic ensure eventual consistency such that the scheduler will send the correct number of emails even if it misses a day or two.

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Testing

Refer to integration testing in ci.yaml or checkout into branch `feat/90-notification-logic` 

run `go test ./...` 

### Screenshots (if applicable) 

N/A

### Related Issue/Ticket

closes #90 

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes

> Note: Integration Tests do not currently pass
