### PR TITLE
refactor: catch blocked http requests

### DIFF
--- a/internal/utils/email.go
+++ b/internal/utils/email.go
@@ -45,19 +45,27 @@ func SendNotif(client *http.Client, conf structInternal.EmailConfig, email strin
 
 	if err != nil {
 		log.Printf("Error creating request: %v", err)
+	} else {
+		log.Printf("Successfully created HTTP request")
 	}
 
 	// Send Request
 	response, err := client.Do(request)
 
+	if response != nil {
+		defer response.Body.Close()
+	}
+
 	if err != nil {
 		log.Printf("Error making HTTP POST request: %v", err)
 
 		// sending the email failed, but don't stop the program
-		return errors.New(response.Status)
-	}
+		if response != nil {
+			return errors.New(response.Status)
+		}
 
-	defer response.Body.Close()
+		return errors.New("Error returning an HTTP response")
+	}
 
 	log.Printf("Successfully Sent Email Notif to %s: %s", personal.Name, response.Status)
 
@@ -101,6 +109,9 @@ func nsEmail(kube kubernetes.Interface, name string) string {
 	email := ns.Annotations["owner"]
 	if email == "" {
 		log.Printf("Error: Annotation 'owner' for namespace %s is empty", name)
+	} else {
+		log.Printf("Successfully acquired owner email %s", email)
 	}
+
 	return email
 }


### PR DESCRIPTION
### Proposed Changes/Description 

`response.Status` was returning a segmentation fault since response was nil, accessing `response.Status` was causing an error. This change fixes that.

This change also moves the response defer operation to be closer to its creation and adds additional logging

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [x] Other (if none of the other choices apply)

### Testing

N/A (Just a small minor logging change)

### Screenshots (if applicable) 

N/A 

### Related Issue/Ticket

closes #113 

### Checklist

- [ ] ~README.md or the Github Wiki documentation updated - if appropriate~
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
