### PR TITLE
fix(retrieve.go): handle empty vol in sts

### DIFF
--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -91,14 +91,18 @@ func FindUnattachedPVCs(kube kubernetes.Interface) []corev1.PersistentVolumeClai
 		for _, statefulset := range StsList(kube, namespace.Name) {
 			log.Printf("Found stateful set: %s", statefulset.Name)
 
-			// Spec.Volumes will find all the attached pvcs, not pvs
+			// Spec.Volumes will find all the attached PVCs, not PVs
 
-			for _, claim := range statefulset.Spec.Template.Spec.Volumes {
-				log.Printf("pvc attached to sts: %s", claim.PersistentVolumeClaim.ClaimName)
+			for _, volumes := range statefulset.Spec.Template.Spec.Volumes {
+				if volumes.PersistentVolumeClaim == nil {
+					continue
+				}
+				claim := volumes.PersistentVolumeClaim.ClaimName
 
-				attachedPVCs.Add(claim.PersistentVolumeClaim.ClaimName)
+				log.Printf("pvc attached to sts: %s", claim)
+
+				attachedPVCs.Add(claim)
 			}
-
 		}
 
 		/*

--- a/internal/kubernetes/retriever_test.go
+++ b/internal/kubernetes/retriever_test.go
@@ -138,5 +138,13 @@ func TestFindUnattachedPVCs(t *testing.T) {
 
 		assert.Equal(t, len(FindUnattachedPVCs(kube)), 1)
 
+		// mock a sts with no vols
+		if err := kube.CreateStatefulSet(context.TODO(), "sts-no-volumes", "test"); err != nil {
+			t.Fatalf("error creating sts: %v", err)
+		}
+
+		// no new attachements, expected unattached should still be 1
+		assert.Equal(t, len(FindUnattachedPVCs(kube)), 1)
+
 	})
 }


### PR DESCRIPTION
### Proposed Changes/Description 

- Details on what the PR does
This pr resolves a nil-dereference in retrieve.go at FindUnattachedPVCs.
This happens when the `Volumes` struct has no PVC objects, which are pointers. Attempting to make the reference will break the controller.

This PR:
1. uses `continue` to pass the case where `Volumes` doesn't container any PVC pointers. 
2. updates the function test to account for this case


- Why the change is needed 
It will break
```
controller panic: runtime error: invalid memory address or nil pointer dereference
controller [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17e0fa4]
controller
controller goroutine 1 [running]:
controller volume-cleaner/internal/kubernetes.FindUnattachedPVCs({0x1fadc68, 0xc0003f88c0})
controller     /app/internal/kubernetes/retriever.go:97 +0xba4
controller volume-cleaner/internal/kubernetes.InitialScan({0x1fadc68, 0xc0003f88c0}, {{0xc000010010, 0x0}, {0xc00004403b, 0x1e}, {0xc00004400c, 0x21}, {0xc00004600c, 0x
controller     /app/internal/kubernetes/watcher.go:74 +0xbe
controller main.main()
controller     /app/cmd/controller/main.go:48 +0x205
```

- Any additional context about this PR
non

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Testing

Steps to reproduce the issue and verify the change/fix

1. Step 1 create an STS without an attached PVC but other volume objects
3. Step 2 wait for controller to pick it up
4. Step 3 gg

### Screenshots (if applicable) 

Include before/after screenshots or links 
No before screenshot, I dumped the logs instead.

### Related Issue/Ticket

Link to the related issue(s) on Github or Jira
No issue created

### Checklist

- [ ] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [ ] Lint and Unit tests pass locally with my changes
