### PR TITLE
fix: remove error throwing from func RemovePVCLabel

### DIFF
--- a/internal/kubernetes/labeller.go
+++ b/internal/kubernetes/labeller.go
@@ -38,15 +38,5 @@ func SetPvcLabel(kube kubernetes.Interface, label string, value string, ns strin
 
 // setting label to null (not "null") will remove it
 func RemovePvcLabel(kube kubernetes.Interface, label string, ns string, pvc string) {
-	pvcObj, err := kube.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvc, metav1.GetOptions{})
-	if err != nil {
-		log.Printf("Error getting PVC to patch: %s", err)
-		return
-	}
-	_, ok := pvcObj.Labels[label]
-	if !ok {
-		log.Printf("Error removing label %s because label does not exist", label)
-		return
-	}
 	patchPvcLabel(kube, label, "null", ns, pvc)
 }

--- a/internal/kubernetes/watcher.go
+++ b/internal/kubernetes/watcher.go
@@ -53,10 +53,23 @@ func WatchSts(ctx context.Context, kube kubernetes.Interface, cfg structInternal
 						continue
 					}
 
-					log.Printf("removing label")
+					pvcObj, err := kube.CoreV1().PersistentVolumeClaims(sts.Namespace).Get(context.TODO(), vol.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+					if err != nil {
+						log.Printf("Error finding PVC: %s", err)
+						continue
+					}
+					_, ok := pvcObj.Labels[cfg.TimeLabel]
+					if ok {
+						log.Printf("removing label")
+						RemovePvcLabel(kube, cfg.TimeLabel, sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
+					}
 
-					RemovePvcLabel(kube, cfg.TimeLabel, sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
-					RemovePvcLabel(kube, cfg.NotifLabel, sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
+					_, ok = pvcObj.Labels[cfg.NotifLabel]
+					if ok {
+						log.Printf("removing label")
+						RemovePvcLabel(kube, cfg.NotifLabel, sts.Namespace, vol.PersistentVolumeClaim.ClaimName)
+					}
+
 				}
 			case watch.Deleted:
 				log.Printf("sts deleted: %s", sts.Name)


### PR DESCRIPTION
### Proposed Changes/Description 

Inside the function RemovePVCLabels, it would check if the label exists before removing. If it didn't exist, it would log an error, which was confusing. Now, all calls to RemovePVCLabel are expected to work, and the check is done before calling. If the label does not exist, it is not called. In the future, this can be further refactored to return error objects instead.

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
