### PR TITLE
fix: fix initial startup

### DIFF
--- a/internal/kubernetes/retriever.go
+++ b/internal/kubernetes/retriever.go
@@ -75,6 +75,11 @@ func FindUnattachedPVCs(kube kubernetes.Interface, cfg structInternal.Controller
 	log.Print("Scanning namespaces...")
 
 	for _, namespace := range NsList(kube) {
+		// skip if not in configured namespace
+		if namespace.Name != cfg.Namespace && cfg.Namespace != "" {
+			continue
+		}
+
 		log.Printf("Found namespace: %s", namespace.Name)
 		log.Print("Scanning persistent volume claims...")
 

--- a/internal/kubernetes/retriever_test.go
+++ b/internal/kubernetes/retriever_test.go
@@ -147,5 +147,16 @@ func TestFindUnattachedPVCs(t *testing.T) {
 		// no new attachements, expected unattached should still be 1
 		assert.Equal(t, len(FindUnattachedPVCs(kube, structure.ControllerConfig{})), 1)
 
+		// create new namespace to see if controller will mark namespaces outside its configured namespace
+
+		if err := kube.CreateNamespace(context.TODO(), "test2", labels); err != nil {
+			t.Fatalf("Error injecting namespace add: %v", err)
+		}
+		// create unattached pvc for second namespace
+		if _, pvcErr := kube.CreatePersistentVolumeClaim(context.TODO(), "pvc3", "test2"); pvcErr != nil {
+			t.Fatalf("Error injecting pvc add: %v", pvcErr)
+		}
+
+		assert.Equal(t, len(FindUnattachedPVCs(kube, structure.ControllerConfig{Namespace: "test"})), 1)
 	})
 }


### PR DESCRIPTION
### Proposed Changes/Description 

The initial startup was not bound by the configured namespace. Instead, it applied labels to every unattached pvc in the cluster. Now, the startup phase will only apply labels to pvcs within the configured namespace. Not to be confused with #68, during which the controller would re-label pvcs that already had labels. This pr fixes the bug where the controller shouldn't even check pvcs outside its scope at all.

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Related Issue/Ticket

closes #137

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [x] Unit and/or integration tests added/modified
- [x] Lint and Unit tests pass locally with my changes
