### PR TITLE
docs: add in-cluster running architectural diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Despite being primarily designed for Statistics Canada, this project strongly va
 ### Architectural Structure
 
 **DevOps Build Process**
-<img width="3005" height="1836" alt="isoflow-export-2025-07-25T17_59_53 322Z (1)" src="https://github.com/user-attachments/assets/07d69a08-f164-4f17-b83f-2bb5fe66fa4a" />
+<img width="3005" height="1836" alt="DevOps Build Process Diagram" src="https://github.com/user-attachments/assets/07d69a08-f164-4f17-b83f-2bb5fe66fa4a" />
 
 **In-Cluster Running Process**
-<img width="845" height="722" alt="Volume Cleaner Architectural Diagram" src="https://github.com/user-attachments/assets/2ec877ac-cb72-4337-914d-115e0172405f" />
+<img width="2748" height="1672" alt="Volume Cleaner Architectural Diagram" src="https://github.com/user-attachments/assets/8270c26d-dae3-437c-b134-880ccac756ed" />
 
 ## Requirements
 
@@ -208,7 +208,11 @@ Bien qu'il soit principalement conçu pour Statistique Canada, ce projet valoris
 
 ### Structure architecturale
 
-<img width="845" height="722" alt="Schéma d'architecture du volume-cleaner" src="https://github.com/user-attachments/assets/22da4862-704d-49e4-b757-29eff1c29db4" />
+**Processus de build DevOps**
+<img width="3005" height="1836" alt="Processus de build DevOps du volume-cleaner" src="https://github.com/user-attachments/assets/07d69a08-f164-4f17-b83f-2bb5fe66fa4a" />
+
+**Processus en cours d’exécution dans le cluster**
+<img width="2748" height="1672" alt="Schéma d'architecture du volume-cleaner" src="https://github.com/user-attachments/assets/8270c26d-dae3-437c-b134-880ccac756ed" />
 
 ## Prérequis
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Despite being primarily designed for Statistics Canada, this project strongly va
 <img width="3005" height="1836" alt="DevOps Build Process Diagram" src="https://github.com/user-attachments/assets/07d69a08-f164-4f17-b83f-2bb5fe66fa4a" />
 
 **In-Cluster Running Process**
-<img width="2748" height="1672" alt="Volume Cleaner Architectural Diagram" src="https://github.com/user-attachments/assets/8270c26d-dae3-437c-b134-880ccac756ed" />
+<img width="2770" height="1782" alt="Volume Cleaner Architectural Diagram" src="https://github.com/user-attachments/assets/b50b905e-49dd-4747-bfd6-906afcb02494" />
 
 ## Requirements
 
@@ -212,7 +212,7 @@ Bien qu'il soit principalement conçu pour Statistique Canada, ce projet valoris
 <img width="3005" height="1836" alt="Processus de build DevOps du volume-cleaner" src="https://github.com/user-attachments/assets/07d69a08-f164-4f17-b83f-2bb5fe66fa4a" />
 
 **Processus en cours d’exécution dans le cluster**
-<img width="2748" height="1672" alt="Schéma d'architecture du volume-cleaner" src="https://github.com/user-attachments/assets/8270c26d-dae3-437c-b134-880ccac756ed" />
+<img width="2770" height="1782" alt="Schéma d'architecture du volume-cleaner" src="https://github.com/user-attachments/assets/b50b905e-49dd-4747-bfd6-906afcb02494" />
 
 ## Prérequis
 


### PR DESCRIPTION
### Proposed Changes/Description 

- To have continuity between the build process diagram and the running in-cluster

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Testing

Refer to README.md for details

### Screenshots (if applicable) 

<img width="2770" height="1782" alt="Volume-Cleaner-Running" src="https://github.com/user-attachments/assets/6d98ecc9-7935-49a8-8562-75f3858f5b71" />

### Related Issue/Ticket

closes #149 

### Checklist

- [x] README.md or the Github Wiki documentation updated - if appropriate
- [ ] ~Unit and/or integration tests added/modified~
- [ ] ~Lint and Unit tests pass locally with my changes~
